### PR TITLE
feat: add base64 encoding for commands in raw TCP sessions

### DIFF
--- a/internal/encoding.go
+++ b/internal/encoding.go
@@ -1,0 +1,19 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/base64"
+)
+
+// Checks if it's printable ASCII, otherwise returns base64-encoded string of the input, stripping trailing newlines and carriage returns
+func PlainOrBase64(s []byte) (value string) {
+	// trim trailing newlines and carriage returns
+	s = bytes.TrimRight(s, "\r\n")
+	for _, r := range s {
+		if r < 32 || r > 126 { // Noisy characters
+			return base64.StdEncoding.EncodeToString(s)
+		}
+	}
+
+	return string(s)
+}

--- a/internal/encoding_test.go
+++ b/internal/encoding_test.go
@@ -1,0 +1,45 @@
+package internal
+
+import "testing"
+
+func TestPlainOrBase64(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want string
+	}{
+		{
+			name: "valid printable ASCII is returned as plain text",
+			in:   []byte("hello world"),
+			want: "hello world",
+		},
+		{
+			name: "valid printable ASCII has trailing line endings trimmed",
+			in:   []byte("hello world\r\n"),
+			want: "hello world",
+		},
+		{
+			name: "invalid low control byte is returned as base64",
+			in:   []byte{'h', 'i', 0x00},
+			want: "aGkA",
+		},
+		{
+			name: "invalid high byte is returned as base64",
+			in:   []byte{0xff, 0xfe},
+			want: "//4=",
+		},
+		{
+			name: "invalid bytes have trailing line endings trimmed before base64",
+			in:   []byte{'o', 'k', 0x00, '\r', '\n'},
+			want: "b2sA",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PlainOrBase64(tt.in); got != tt.want {
+				t.Fatalf("PlainOrBase64(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/protocols/strategies/TCP/tcp.go
+++ b/internal/protocols/strategies/TCP/tcp.go
@@ -77,11 +77,10 @@ func handleTCPConnection(conn net.Conn, servConf parser.BeelzebubServiceConfigur
 		commandRaw := ""
 
 		if n, err := conn.Read(buffer); err == nil {
-			command = string(buffer[:n])
 			if !utf8.Valid(buffer[:n]) {
 				commandRaw = hexEscapeNonPrintable(buffer[:n])
 			}
-			command = internal.PlainOrBase64([]byte(commandRaw))
+			command = internal.PlainOrBase64(buffer[:n])
 		}
 
 		tr.TraceEvent(tracer.Event{
@@ -134,8 +133,8 @@ func handleTCPConnection(conn net.Conn, servConf parser.BeelzebubServiceConfigur
 		// protocols), so the forensic record survives string()'s U+FFFD
 		// substitution. Empty for UTF-8 traffic.
 		commandRaw := ""
-		if !utf8.Valid([]byte(commandInput)) {
-			commandRaw = hexEscapeNonPrintable([]byte(commandInput))
+		if !utf8.Valid(buffer[:n]) {
+			commandRaw = hexEscapeNonPrintable(buffer[:n])
 		}
 
 		// Match command against regexes

--- a/internal/protocols/strategies/TCP/tcp.go
+++ b/internal/protocols/strategies/TCP/tcp.go
@@ -8,6 +8,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/beelzebub-labs/beelzebub/v3/internal"
 	"github.com/beelzebub-labs/beelzebub/v3/internal/historystore"
 	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
 	"github.com/beelzebub-labs/beelzebub/v3/internal/plugins"
@@ -80,6 +81,7 @@ func handleTCPConnection(conn net.Conn, servConf parser.BeelzebubServiceConfigur
 			if !utf8.Valid(buffer[:n]) {
 				commandRaw = hexEscapeNonPrintable(buffer[:n])
 			}
+			command = internal.PlainOrBase64([]byte(commandRaw))
 		}
 
 		tr.TraceEvent(tracer.Event{
@@ -132,8 +134,8 @@ func handleTCPConnection(conn net.Conn, servConf parser.BeelzebubServiceConfigur
 		// protocols), so the forensic record survives string()'s U+FFFD
 		// substitution. Empty for UTF-8 traffic.
 		commandRaw := ""
-		if !utf8.Valid(buffer[:n]) {
-			commandRaw = hexEscapeNonPrintable(buffer[:n])
+		if !utf8.Valid([]byte(commandInput)) {
+			commandRaw = hexEscapeNonPrintable([]byte(commandInput))
 		}
 
 		// Match command against regexes
@@ -189,7 +191,7 @@ func handleTCPConnection(conn net.Conn, servConf parser.BeelzebubServiceConfigur
 					SourceIp:      host,
 					SourcePort:    port,
 					Status:        tracer.Interaction.String(),
-					Command:       commandInput,
+					Command:       internal.PlainOrBase64([]byte(commandInput)),
 					CommandRaw:    commandRaw,
 					CommandOutput: commandOutput,
 					ID:            sessionID.String(),
@@ -210,7 +212,7 @@ func handleTCPConnection(conn net.Conn, servConf parser.BeelzebubServiceConfigur
 				SourceIp:    host,
 				SourcePort:  port,
 				Status:      tracer.Interaction.String(),
-				Command:     commandInput,
+				Command:     internal.PlainOrBase64([]byte(commandInput)),
 				CommandRaw:  commandRaw,
 				ID:          sessionID.String(),
 				Protocol:    tracer.TCP.String(),

--- a/internal/protocols/strategies/TCP/tcp_test.go
+++ b/internal/protocols/strategies/TCP/tcp_test.go
@@ -1,6 +1,7 @@
 package TCP
 
 import (
+	"encoding/base64"
 	"net"
 	"regexp"
 	"strings"
@@ -269,4 +270,48 @@ func TestHandleTCPConnection_SessionStart(t *testing.T) {
 	}
 	assert.True(t, hasStart, "expected session start event")
 	assert.True(t, hasEnd, "expected session end event")
+}
+
+func TestHandleTCPConnection_CommandWithNoHandlerAndUnprintableBytes(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+
+	mt := &mockTracer{}
+	servConf := parser.BeelzebubServiceConfiguration{
+		Description:            "test",
+		DeadlineTimeoutSeconds: 5,
+		Commands:               []parser.Command{},
+	}
+	strategy := newStrategyWithSessions()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleTCPConnection(server, servConf, mt, strategy)
+	}()
+
+	// This is a load of unprintable bytes to test the base64 encoding of the command in the event
+	inputData := []byte{94, 92, 117, 102, 102, 102, 100, 92, 92, 206, 141, 92, 117, 102, 102, 102, 100, 92, 117, 102,
+		102, 102, 100, 92, 117, 102, 102, 102, 100, 92, 117, 102, 102, 102, 100, 92, 117, 48, 48, 49, 53, 92, 117, 102,
+	}
+
+	client.Write(inputData)
+	time.Sleep(100 * time.Millisecond)
+	client.Close()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	found := false
+	for _, e := range mt.events {
+		if e.Command == base64.StdEncoding.EncodeToString(inputData) {
+			found = true
+			break
+		}
+	}
+
+	assert.True(t, found, "expected an interaction event with command")
 }


### PR DESCRIPTION
This base64-encodes logging for commands that come through on the TCP channel if it includes unprintable code points, ref #315 

I'm a newbie golang programmer, so if there's a better place to put the function or structure the code don't feel bad providing feedback 😄 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally before submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
