### PR TITLE
feat(http): add method-aware routing to reduce fingerprinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ address: ":80"
 description: "Wordpress 6.0"
 commands:
   - regex: "^(/index.php|/index.html|/)$"
+    methods: [GET]
     handler: |
       <html><header><title>Wordpress 6 test page</title></header>
       <body><h1>Hello from Wordpress</h1></body></html>
@@ -418,6 +419,7 @@ commands:
       - "X-Powered-By: PHP/7.4.29"
     statusCode: 200
   - regex: "^(/wp-login.php|/wp-admin)$"
+    methods: [GET, POST]
     handler: |
       <html><body>
         <form method="post">
@@ -436,6 +438,8 @@ commands:
       - "Content-Type: text/html"
     statusCode: 404
 ```
+
+Each command may declare an optional `methods` list. A request returns `405 Method Not Allowed` and an `Allow` header only when one or more command regexes match but none accepts its method; an unrestricted catch-all still handles every method. Omitting `methods` accepts every method.
 
 **LLM-powered HTTP service**  add a `fallbackCommand` with `plugin: LLMHoneypot` to generate dynamic responses for any unmatched request.
 

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ address: ":80"
 description: "Wordpress 6.0"
 commands:
   - regex: "^(/index.php|/index.html|/)$"
-    methods: [GET]
+    methods: [GET, HEAD]
     handler: |
       <html><header><title>Wordpress 6 test page</title></header>
       <body><h1>Hello from Wordpress</h1></body></html>
@@ -419,7 +419,7 @@ commands:
       - "X-Powered-By: PHP/7.4.29"
     statusCode: 200
   - regex: "^(/wp-login.php|/wp-admin)$"
-    methods: [GET, POST]
+    methods: [GET, HEAD, POST]
     handler: |
       <html><body>
         <form method="post">
@@ -439,7 +439,7 @@ commands:
     statusCode: 404
 ```
 
-Each command may declare an optional `methods` list. A request returns `405 Method Not Allowed` and an `Allow` header only when one or more command regexes match but none accepts its method; an unrestricted catch-all still handles every method. Omitting `methods` accepts every method.
+Each command may declare an optional `methods` list. A request returns `405 Method Not Allowed` and an `Allow` header only when one or more command regexes match but none accepts its method; an unrestricted catch-all still handles every method. Omitting `methods` accepts every method. `GET` does not automatically imply `HEAD`; configure each method explicitly according to the emulated stack.
 
 **LLM-powered HTTP service**  add a `fallbackCommand` with `plugin: LLMHoneypot` to generate dynamic responses for any unmatched request.
 

--- a/configurations/services/http-methods-8081.yaml
+++ b/configurations/services/http-methods-8081.yaml
@@ -1,0 +1,16 @@
+apiVersion: "v1"
+protocol: "http"
+address: ":8081"
+description: "HTTP method example"
+commands:
+  - regex: "^/hello$"
+    methods: [GET]
+    handler: "Hello!"
+    statusCode: 200
+  - regex: "^/submit$"
+    methods: [POST]
+    handler: "Submitted!"
+    statusCode: 200
+fallbackCommand:
+  handler: "404 Not Found!"
+  statusCode: 404

--- a/docs/configuration-validation.md
+++ b/docs/configuration-validation.md
@@ -127,6 +127,7 @@ make validate-all          # validate-specs + beelzebub validate (full)
 | **Commands** | `commands` required for HTTP (min 1) | Schema | Error |
 | **Commands** | `commands` required for TELNET (min 1) | Schema | Error |
 | **Commands** | `commands[].regex` non-empty | Schema + Go | Error |
+| **Commands** | `commands[].methods` entries non-empty and unique | Schema | Error |
 | **Commands** | `commands[].plugin` enum valid | Schema | Error |
 | **Commands** | `commands[].handler` empty + `plugin` empty | Go | Warning |
 | **Commands** | `commands[].headers` format `key: value` | Go | Warning |

--- a/internal/parser/configurations_parser.go
+++ b/internal/parser/configurations_parser.go
@@ -114,6 +114,7 @@ func (bsc BeelzebubServiceConfiguration) HashCode() (string, error) {
 type Command struct {
 	RegexStr   string         `yaml:"regex" json:"regex,omitempty"`
 	Regex      *regexp.Regexp `yaml:"-" json:"-"` // This field is parsed, not stored in the config itself.
+	Methods    []string       `yaml:"methods" json:"methods,omitempty"`
 	Handler    string         `yaml:"handler" json:"handler,omitempty"`
 	Headers    []string       `yaml:"headers" json:"headers,omitempty"`
 	StatusCode int            `yaml:"statusCode" json:"statusCode,omitempty"`

--- a/internal/parser/configurations_parser_test.go
+++ b/internal/parser/configurations_parser_test.go
@@ -66,6 +66,7 @@ tools:
     handler: "reset_password ok"
 commands:
   - regex: "wp-admin"
+    methods: [GET, POST]
     handler: "login"
     headers:
       - "Content-Type: text/html"
@@ -225,6 +226,7 @@ func TestReadConfigurationsServicesValid(t *testing.T) {
 	assert.Equal(t, len(firstBeelzebubServiceConfiguration.Commands), 2)
 	assert.Equal(t, firstBeelzebubServiceConfiguration.Commands[0].RegexStr, "wp-admin")
 	assert.Equal(t, firstBeelzebubServiceConfiguration.Commands[0].Regex.String(), "wp-admin")
+	assert.Equal(t, []string{"GET", "POST"}, firstBeelzebubServiceConfiguration.Commands[0].Methods)
 	assert.Equal(t, firstBeelzebubServiceConfiguration.Commands[0].Handler, "login")
 	assert.Equal(t, len(firstBeelzebubServiceConfiguration.Commands[0].Headers), 1)
 	assert.Equal(t, firstBeelzebubServiceConfiguration.Commands[0].Headers[0], "Content-Type: text/html")
@@ -279,7 +281,7 @@ func TestReadConfigurationsServicesGenerateHashCode(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Nil(t, errHashCode)
-	assert.Equal(t, "34c8a2e81787e09f9e24efd6f60b2ceb808e47d9fa180ea8af9f054797ad4e00", hashCode)
+	assert.Equal(t, "9c9c924bbe65f4f39bf9698248ece5c5d8f298932bd5f4d974915510b95f023f", hashCode)
 }
 
 func TestReadConfigurationsPluginGuardrailsValid(t *testing.T) {
@@ -620,7 +622,7 @@ func TestToolAnnotationsHashCodeStability(t *testing.T) {
 	// the hash for configs that don't use annotations
 	hashCode, errHashCode := beelzebubServicesConfiguration[0].HashCode()
 	assert.Nil(t, errHashCode)
-	assert.Equal(t, "34c8a2e81787e09f9e24efd6f60b2ceb808e47d9fa180ea8af9f054797ad4e00", hashCode)
+	assert.Equal(t, "9c9c924bbe65f4f39bf9698248ece5c5d8f298932bd5f4d974915510b95f023f", hashCode)
 }
 
 func TestReadConfigurationsCoreEnvOverridesFile(t *testing.T) {

--- a/internal/parser/schema_validator_test.go
+++ b/internal/parser/schema_validator_test.go
@@ -61,7 +61,7 @@ func TestValidateConfigSchema_Valid(t *testing.T) {
 			config: BeelzebubServiceConfiguration{
 				ApiVersion: "v1",
 				Protocol:   "http", Address: ":8080",
-				Commands: []Command{{RegexStr: ".*", Methods: []string{"GET", "POST"}, Handler: "ok"}},
+				Commands: []Command{{RegexStr: ".*", Methods: []string{"GET", "custom!#$%&'*+-.^_`|~"}, Handler: "ok"}},
 			},
 		},
 		{
@@ -231,6 +231,14 @@ func TestValidateConfigSchema_Invalid(t *testing.T) {
 				Commands: []Command{{RegexStr: ".*", Methods: []string{"GET", "GET"}, Handler: "ok"}},
 			},
 			msg: "equal",
+		},
+		{
+			name: "HTTP method with delimiter",
+			config: BeelzebubServiceConfiguration{
+				ApiVersion: "v1", Protocol: "http", Address: ":8080",
+				Commands: []Command{{RegexStr: ".*", Methods: []string{"GET/POST"}, Handler: "ok"}},
+			},
+			msg: "pattern",
 		},
 	}
 

--- a/internal/parser/schema_validator_test.go
+++ b/internal/parser/schema_validator_test.go
@@ -61,7 +61,7 @@ func TestValidateConfigSchema_Valid(t *testing.T) {
 			config: BeelzebubServiceConfiguration{
 				ApiVersion: "v1",
 				Protocol:   "http", Address: ":8080",
-				Commands: []Command{{RegexStr: ".*", Handler: "ok"}},
+				Commands: []Command{{RegexStr: ".*", Methods: []string{"GET", "POST"}, Handler: "ok"}},
 			},
 		},
 		{
@@ -223,6 +223,14 @@ func TestValidateConfigSchema_Invalid(t *testing.T) {
 				Commands: []Command{{RegexStr: "^ls$", Handler: "files"}},
 			},
 			msg: "missing property",
+		},
+		{
+			name: "duplicate HTTP methods",
+			config: BeelzebubServiceConfiguration{
+				ApiVersion: "v1", Protocol: "http", Address: ":8080",
+				Commands: []Command{{RegexStr: ".*", Methods: []string{"GET", "GET"}, Handler: "ok"}},
+			},
+			msg: "equal",
 		},
 	}
 

--- a/internal/protocols/strategies/HTTP/http.go
+++ b/internal/protocols/strategies/HTTP/http.go
@@ -69,6 +69,7 @@ func newHTTPHandler(servConf parser.BeelzebubServiceConfiguration, tr tracer.Tra
 			resp.StatusCode = http.StatusMethodNotAllowed
 			resp.Headers = []string{"Allow:" + strings.Join(allowedMethods, ", ")}
 			resp.Body = http.StatusText(http.StatusMethodNotAllowed)
+			traceRequest(request, tr, parser.Command{}, servConf.Description, "", servConf.TrustedProxiesNets)
 		} else {
 			// If none of the main commands matched, and we have a fallback command configured, process it here.
 			// The regexp is ignored for fallback commands, as they are catch-all for any request.

--- a/internal/protocols/strategies/HTTP/http.go
+++ b/internal/protocols/strategies/HTTP/http.go
@@ -29,7 +29,32 @@ type httpResponse struct {
 func (httpStrategy HTTPStrategy) Init(servConf parser.BeelzebubServiceConfiguration, tr tracer.Tracer) error {
 	serverMux := http.NewServeMux()
 
-	serverMux.HandleFunc("/", func(responseWriter http.ResponseWriter, request *http.Request) {
+	serverMux.HandleFunc("/", newHTTPHandler(servConf, tr))
+	go func() {
+		var err error
+		// Launch a TLS supporting server if we are supplied a TLS Key and Certificate.
+		// If relative paths are supplied, they are relative to the CWD of the binary.
+		// The can be self-signed, only the client will validate this (or not).
+		if servConf.TLSKeyPath != "" && servConf.TLSCertPath != "" {
+			err = http.ListenAndServeTLS(servConf.Address, servConf.TLSCertPath, servConf.TLSKeyPath, serverMux)
+		} else {
+			err = http.ListenAndServe(servConf.Address, serverMux)
+		}
+		if err != nil {
+			log.Errorf("error during init HTTP Protocol: %v", err)
+			return
+		}
+	}()
+
+	log.WithFields(log.Fields{
+		"port":     servConf.Address,
+		"commands": len(servConf.Commands),
+	}).Infof("Init service: %s", servConf.Description)
+	return nil
+}
+
+func newHTTPHandler(servConf parser.BeelzebubServiceConfiguration, tr tracer.Tracer) http.HandlerFunc {
+	return func(responseWriter http.ResponseWriter, request *http.Request) {
 		var resp httpResponse
 		var err error
 		command, allowedMethods := matchHTTPCommand(servConf.Commands, request)
@@ -59,29 +84,7 @@ func (httpStrategy HTTPStrategy) Init(servConf parser.BeelzebubServiceConfigurat
 		}
 		setResponseHeaders(responseWriter, resp.Headers, resp.StatusCode)
 		fmt.Fprint(responseWriter, resp.Body)
-
-	})
-	go func() {
-		var err error
-		// Launch a TLS supporting server if we are supplied a TLS Key and Certificate.
-		// If relative paths are supplied, they are relative to the CWD of the binary.
-		// The can be self-signed, only the client will validate this (or not).
-		if servConf.TLSKeyPath != "" && servConf.TLSCertPath != "" {
-			err = http.ListenAndServeTLS(servConf.Address, servConf.TLSCertPath, servConf.TLSKeyPath, serverMux)
-		} else {
-			err = http.ListenAndServe(servConf.Address, serverMux)
-		}
-		if err != nil {
-			log.Errorf("error during init HTTP Protocol: %v", err)
-			return
-		}
-	}()
-
-	log.WithFields(log.Fields{
-		"port":     servConf.Address,
-		"commands": len(servConf.Commands),
-	}).Infof("Init service: %s", servConf.Description)
-	return nil
+	}
 }
 
 func matchHTTPCommand(commands []parser.Command, request *http.Request) (*parser.Command, []string) {

--- a/internal/protocols/strategies/HTTP/http.go
+++ b/internal/protocols/strategies/HTTP/http.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/beelzebub-labs/beelzebub/v3/internal/parser"
@@ -28,40 +29,7 @@ type httpResponse struct {
 func (httpStrategy HTTPStrategy) Init(servConf parser.BeelzebubServiceConfiguration, tr tracer.Tracer) error {
 	serverMux := http.NewServeMux()
 
-	serverMux.HandleFunc("/", func(responseWriter http.ResponseWriter, request *http.Request) {
-		var matched bool
-		var resp httpResponse
-		var err error
-		for _, command := range servConf.Commands {
-			var err error
-			matched = command.Regex.MatchString(request.RequestURI)
-			if matched {
-				resp, err = buildHTTPResponse(servConf, tr, command, request)
-				if err != nil {
-					log.Errorf("error building http response: %s: %v", request.RequestURI, err)
-					resp.StatusCode = 500
-					resp.Body = "500 Internal Server Error"
-				}
-				break
-			}
-		}
-		// If none of the main commands matched, and we have a fallback command configured, process it here.
-		// The regexp is ignored for fallback commands, as they are catch-all for any request.
-		if !matched {
-			command := servConf.FallbackCommand
-			if command.Handler != "" || command.Plugin != "" {
-				resp, err = buildHTTPResponse(servConf, tr, command, request)
-				if err != nil {
-					log.Errorf("error building http response: %s: %v", request.RequestURI, err)
-					resp.StatusCode = 500
-					resp.Body = "500 Internal Server Error"
-				}
-			}
-		}
-		setResponseHeaders(responseWriter, resp.Headers, resp.StatusCode)
-		fmt.Fprint(responseWriter, resp.Body)
-
-	})
+	serverMux.HandleFunc("/", newHTTPHandler(servConf, tr))
 	go func() {
 		var err error
 		// Launch a TLS supporting server if we are supplied a TLS Key and Certificate.
@@ -83,6 +51,59 @@ func (httpStrategy HTTPStrategy) Init(servConf parser.BeelzebubServiceConfigurat
 		"commands": len(servConf.Commands),
 	}).Infof("Init service: %s", servConf.Description)
 	return nil
+}
+
+func newHTTPHandler(servConf parser.BeelzebubServiceConfiguration, tr tracer.Tracer) http.HandlerFunc {
+	return func(responseWriter http.ResponseWriter, request *http.Request) {
+		var matched, pathMatched bool
+		var allowedMethods []string
+		var resp httpResponse
+		var err error
+
+		for _, command := range servConf.Commands {
+			if !command.Regex.MatchString(request.RequestURI) {
+				continue
+			}
+			pathMatched = true
+			if len(command.Methods) > 0 && !slices.Contains(command.Methods, request.Method) {
+				for _, method := range command.Methods {
+					if !slices.Contains(allowedMethods, method) {
+						allowedMethods = append(allowedMethods, method)
+					}
+				}
+				continue
+			}
+			matched = true
+			resp, err = buildHTTPResponse(servConf, tr, command, request)
+			if err != nil {
+				log.Errorf("error building http response: %s: %v", request.RequestURI, err)
+				resp.StatusCode = http.StatusInternalServerError
+				resp.Body = "500 Internal Server Error"
+			}
+			break
+		}
+
+		if !matched {
+			if pathMatched {
+				resp.StatusCode = http.StatusMethodNotAllowed
+				resp.Headers = []string{"Allow:" + strings.Join(allowedMethods, ", ")}
+				resp.Body = http.StatusText(http.StatusMethodNotAllowed)
+			} else {
+				command := servConf.FallbackCommand
+				if command.Handler != "" || command.Plugin != "" {
+					resp, err = buildHTTPResponse(servConf, tr, command, request)
+					if err != nil {
+						log.Errorf("error building http response: %s: %v", request.RequestURI, err)
+						resp.StatusCode = http.StatusInternalServerError
+						resp.Body = "500 Internal Server Error"
+					}
+				}
+			}
+		}
+
+		setResponseHeaders(responseWriter, resp.Headers, resp.StatusCode)
+		fmt.Fprint(responseWriter, resp.Body)
+	}
 }
 
 func buildHTTPResponse(servConf parser.BeelzebubServiceConfiguration, tr tracer.Tracer, command parser.Command, request *http.Request) (httpResponse, error) {

--- a/internal/protocols/strategies/HTTP/http.go
+++ b/internal/protocols/strategies/HTTP/http.go
@@ -29,7 +29,38 @@ type httpResponse struct {
 func (httpStrategy HTTPStrategy) Init(servConf parser.BeelzebubServiceConfiguration, tr tracer.Tracer) error {
 	serverMux := http.NewServeMux()
 
-	serverMux.HandleFunc("/", newHTTPHandler(servConf, tr))
+	serverMux.HandleFunc("/", func(responseWriter http.ResponseWriter, request *http.Request) {
+		var resp httpResponse
+		var err error
+		command, allowedMethods := matchHTTPCommand(servConf.Commands, request)
+		if command != nil {
+			resp, err = buildHTTPResponse(servConf, tr, *command, request)
+			if err != nil {
+				log.Errorf("error building http response: %s: %v", request.RequestURI, err)
+				resp.StatusCode = 500
+				resp.Body = "500 Internal Server Error"
+			}
+		} else if len(allowedMethods) > 0 {
+			resp.StatusCode = http.StatusMethodNotAllowed
+			resp.Headers = []string{"Allow:" + strings.Join(allowedMethods, ", ")}
+			resp.Body = http.StatusText(http.StatusMethodNotAllowed)
+		} else {
+			// If none of the main commands matched, and we have a fallback command configured, process it here.
+			// The regexp is ignored for fallback commands, as they are catch-all for any request.
+			command := servConf.FallbackCommand
+			if command.Handler != "" || command.Plugin != "" {
+				resp, err = buildHTTPResponse(servConf, tr, command, request)
+				if err != nil {
+					log.Errorf("error building http response: %s: %v", request.RequestURI, err)
+					resp.StatusCode = 500
+					resp.Body = "500 Internal Server Error"
+				}
+			}
+		}
+		setResponseHeaders(responseWriter, resp.Headers, resp.StatusCode)
+		fmt.Fprint(responseWriter, resp.Body)
+
+	})
 	go func() {
 		var err error
 		// Launch a TLS supporting server if we are supplied a TLS Key and Certificate.
@@ -53,57 +84,23 @@ func (httpStrategy HTTPStrategy) Init(servConf parser.BeelzebubServiceConfigurat
 	return nil
 }
 
-func newHTTPHandler(servConf parser.BeelzebubServiceConfiguration, tr tracer.Tracer) http.HandlerFunc {
-	return func(responseWriter http.ResponseWriter, request *http.Request) {
-		var matched, pathMatched bool
-		var allowedMethods []string
-		var resp httpResponse
-		var err error
-
-		for _, command := range servConf.Commands {
-			if !command.Regex.MatchString(request.RequestURI) {
-				continue
-			}
-			pathMatched = true
-			if len(command.Methods) > 0 && !slices.Contains(command.Methods, request.Method) {
-				for _, method := range command.Methods {
-					if !slices.Contains(allowedMethods, method) {
-						allowedMethods = append(allowedMethods, method)
-					}
-				}
-				continue
-			}
-			matched = true
-			resp, err = buildHTTPResponse(servConf, tr, command, request)
-			if err != nil {
-				log.Errorf("error building http response: %s: %v", request.RequestURI, err)
-				resp.StatusCode = http.StatusInternalServerError
-				resp.Body = "500 Internal Server Error"
-			}
-			break
+func matchHTTPCommand(commands []parser.Command, request *http.Request) (*parser.Command, []string) {
+	var allowedMethods []string
+	for i := range commands {
+		command := &commands[i]
+		if !command.Regex.MatchString(request.RequestURI) {
+			continue
 		}
-
-		if !matched {
-			if pathMatched {
-				resp.StatusCode = http.StatusMethodNotAllowed
-				resp.Headers = []string{"Allow:" + strings.Join(allowedMethods, ", ")}
-				resp.Body = http.StatusText(http.StatusMethodNotAllowed)
-			} else {
-				command := servConf.FallbackCommand
-				if command.Handler != "" || command.Plugin != "" {
-					resp, err = buildHTTPResponse(servConf, tr, command, request)
-					if err != nil {
-						log.Errorf("error building http response: %s: %v", request.RequestURI, err)
-						resp.StatusCode = http.StatusInternalServerError
-						resp.Body = "500 Internal Server Error"
-					}
-				}
+		if len(command.Methods) == 0 || slices.Contains(command.Methods, request.Method) {
+			return command, nil
+		}
+		for _, method := range command.Methods {
+			if !slices.Contains(allowedMethods, method) {
+				allowedMethods = append(allowedMethods, method)
 			}
 		}
-
-		setResponseHeaders(responseWriter, resp.Headers, resp.StatusCode)
-		fmt.Fprint(responseWriter, resp.Body)
 	}
+	return nil, allowedMethods
 }
 
 func buildHTTPResponse(servConf parser.BeelzebubServiceConfiguration, tr tracer.Tracer, command parser.Command, request *http.Request) (httpResponse, error) {

--- a/internal/protocols/strategies/HTTP/http_test.go
+++ b/internal/protocols/strategies/HTTP/http_test.go
@@ -584,6 +584,22 @@ func TestHTTPHandler_MethodRouting(t *testing.T) {
 			wantStatus: http.StatusNotFound,
 			wantBody:   "fallback",
 		},
+		{
+			name:       "matched plugin error returns internal server error",
+			method:     http.MethodGet,
+			path:       "/error",
+			commands:   []parser.Command{{Regex: regexp.MustCompile(`^/error$`), Plugin: plugins.LLMPluginName}},
+			wantStatus: http.StatusInternalServerError,
+			wantBody:   "500 Internal Server Error",
+		},
+		{
+			name:       "fallback plugin error returns internal server error",
+			method:     http.MethodGet,
+			path:       "/missing",
+			fallback:   parser.Command{Plugin: plugins.LLMPluginName},
+			wantStatus: http.StatusInternalServerError,
+			wantBody:   "500 Internal Server Error",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/protocols/strategies/HTTP/http_test.go
+++ b/internal/protocols/strategies/HTTP/http_test.go
@@ -606,14 +606,16 @@ func TestHTTPHandler_MethodRouting(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			recorder := httptest.NewRecorder()
 			request := httptest.NewRequest(tt.method, tt.path, nil)
+			mt := &mockTracer{}
 			newHTTPHandler(parser.BeelzebubServiceConfiguration{
 				Commands:        tt.commands,
 				FallbackCommand: tt.fallback,
-			}, &mockTracer{}).ServeHTTP(recorder, request)
+			}, mt).ServeHTTP(recorder, request)
 
 			assert.Equal(t, tt.wantStatus, recorder.Code)
 			assert.Equal(t, tt.wantBody, recorder.Body.String())
 			assert.Equal(t, tt.wantAllow, recorder.Header().Get("Allow"))
+			assert.Len(t, mt.events, 1)
 		})
 	}
 }

--- a/internal/protocols/strategies/HTTP/http_test.go
+++ b/internal/protocols/strategies/HTTP/http_test.go
@@ -524,6 +524,84 @@ func TestTraceRequest_RemoteAddr_IPv6WithoutPort(t *testing.T) {
 	assert.Equal(t, "2001:db8::42", ev.RemoteAddr)
 }
 
+func TestHTTPHandler_MethodRouting(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		commands   []parser.Command
+		fallback   parser.Command
+		wantStatus int
+		wantBody   string
+		wantAllow  string
+	}{
+		{
+			name:       "allowed method",
+			method:     http.MethodPost,
+			path:       "/api/generate",
+			commands:   []parser.Command{{Regex: regexp.MustCompile(`^/api/generate$`), Methods: []string{http.MethodPost}, Handler: "generated", StatusCode: http.StatusOK}},
+			wantStatus: http.StatusOK,
+			wantBody:   "generated",
+		},
+		{
+			name:       "missing list accepts every method",
+			method:     http.MethodPatch,
+			path:       "/open",
+			commands:   []parser.Command{{Regex: regexp.MustCompile(`^/open$`), Handler: "open", StatusCode: http.StatusOK}},
+			wantStatus: http.StatusOK,
+			wantBody:   "open",
+		},
+		{
+			name:   "later command accepts method",
+			method: http.MethodPost,
+			path:   "/same",
+			commands: []parser.Command{
+				{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodGet}, Handler: "get", StatusCode: http.StatusOK},
+				{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodPost}, Handler: "post", StatusCode: http.StatusCreated},
+			},
+			wantStatus: http.StatusCreated,
+			wantBody:   "post",
+		},
+		{
+			name:   "known URL rejects method",
+			method: http.MethodDelete,
+			path:   "/same",
+			commands: []parser.Command{
+				{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodGet, http.MethodPost}, Handler: "wrong", StatusCode: http.StatusOK},
+				{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodPost}, Handler: "wrong", StatusCode: http.StatusOK},
+			},
+			fallback:   parser.Command{Handler: "fallback", StatusCode: http.StatusNotFound},
+			wantStatus: http.StatusMethodNotAllowed,
+			wantBody:   http.StatusText(http.StatusMethodNotAllowed),
+			wantAllow:  "GET, POST",
+		},
+		{
+			name:       "unknown URL uses fallback",
+			method:     http.MethodGet,
+			path:       "/missing",
+			commands:   []parser.Command{{Regex: regexp.MustCompile(`^/known$`), Methods: []string{http.MethodGet}, Handler: "known", StatusCode: http.StatusOK}},
+			fallback:   parser.Command{Handler: "fallback", StatusCode: http.StatusNotFound},
+			wantStatus: http.StatusNotFound,
+			wantBody:   "fallback",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(tt.method, tt.path, nil)
+			newHTTPHandler(parser.BeelzebubServiceConfiguration{
+				Commands:        tt.commands,
+				FallbackCommand: tt.fallback,
+			}, &mockTracer{}).ServeHTTP(recorder, request)
+
+			assert.Equal(t, tt.wantStatus, recorder.Code)
+			assert.Equal(t, tt.wantBody, recorder.Body.String())
+			assert.Equal(t, tt.wantAllow, recorder.Header().Get("Allow"))
+		})
+	}
+}
+
 func TestInit_Basic(t *testing.T) {
 	strategy := HTTPStrategy{}
 	tr := &mockTracer{}

--- a/internal/protocols/strategies/HTTP/http_test.go
+++ b/internal/protocols/strategies/HTTP/http_test.go
@@ -524,56 +524,80 @@ func TestTraceRequest_RemoteAddr_IPv6WithoutPort(t *testing.T) {
 	assert.Equal(t, "2001:db8::42", ev.RemoteAddr)
 }
 
-func TestMatchHTTPCommand(t *testing.T) {
-	commands := []parser.Command{
-		{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodGet}, Handler: "get"},
-		{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodPost}, Handler: "post"},
-		{Regex: regexp.MustCompile(`^/open$`), Handler: "open"},
-	}
+func TestHTTPHandler_MethodRouting(t *testing.T) {
 	tests := []struct {
-		name        string
-		method      string
-		path        string
-		wantHandler string
-		wantAllow   []string
+		name       string
+		method     string
+		path       string
+		commands   []parser.Command
+		fallback   parser.Command
+		wantStatus int
+		wantBody   string
+		wantAllow  string
 	}{
 		{
-			name:        "later command accepts method",
-			method:      http.MethodPost,
-			path:        "/same",
-			wantHandler: "post",
+			name:       "allowed method",
+			method:     http.MethodPost,
+			path:       "/api/generate",
+			commands:   []parser.Command{{Regex: regexp.MustCompile(`^/api/generate$`), Methods: []string{http.MethodPost}, Handler: "generated", StatusCode: http.StatusOK}},
+			wantStatus: http.StatusOK,
+			wantBody:   "generated",
 		},
 		{
-			name:        "missing methods accepts every method",
-			method:      http.MethodPatch,
-			path:        "/open",
-			wantHandler: "open",
+			name:       "missing list accepts every method",
+			method:     http.MethodPatch,
+			path:       "/open",
+			commands:   []parser.Command{{Regex: regexp.MustCompile(`^/open$`), Handler: "open", StatusCode: http.StatusOK}},
+			wantStatus: http.StatusOK,
+			wantBody:   "open",
 		},
 		{
-			name:      "known path rejects method",
-			method:    http.MethodDelete,
-			path:      "/same",
-			wantAllow: []string{http.MethodGet, http.MethodPost},
+			name:   "later command accepts method",
+			method: http.MethodPost,
+			path:   "/same",
+			commands: []parser.Command{
+				{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodGet}, Handler: "get", StatusCode: http.StatusOK},
+				{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodPost}, Handler: "post", StatusCode: http.StatusCreated},
+			},
+			wantStatus: http.StatusCreated,
+			wantBody:   "post",
 		},
 		{
-			name:   "unknown path has no allowed methods",
-			method: http.MethodGet,
-			path:   "/missing",
+			name:   "known URL rejects method",
+			method: http.MethodDelete,
+			path:   "/same",
+			commands: []parser.Command{
+				{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodGet, http.MethodPost}, Handler: "wrong", StatusCode: http.StatusOK},
+				{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodPost}, Handler: "wrong", StatusCode: http.StatusOK},
+			},
+			fallback:   parser.Command{Handler: "fallback", StatusCode: http.StatusNotFound},
+			wantStatus: http.StatusMethodNotAllowed,
+			wantBody:   http.StatusText(http.StatusMethodNotAllowed),
+			wantAllow:  "GET, POST",
+		},
+		{
+			name:       "unknown URL uses fallback",
+			method:     http.MethodGet,
+			path:       "/missing",
+			commands:   []parser.Command{{Regex: regexp.MustCompile(`^/known$`), Methods: []string{http.MethodGet}, Handler: "known", StatusCode: http.StatusOK}},
+			fallback:   parser.Command{Handler: "fallback", StatusCode: http.StatusNotFound},
+			wantStatus: http.StatusNotFound,
+			wantBody:   "fallback",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
 			request := httptest.NewRequest(tt.method, tt.path, nil)
-			command, allowedMethods := matchHTTPCommand(commands, request)
+			newHTTPHandler(parser.BeelzebubServiceConfiguration{
+				Commands:        tt.commands,
+				FallbackCommand: tt.fallback,
+			}, &mockTracer{}).ServeHTTP(recorder, request)
 
-			if tt.wantHandler == "" {
-				assert.Nil(t, command)
-			} else {
-				require.NotNil(t, command)
-				assert.Equal(t, tt.wantHandler, command.Handler)
-			}
-			assert.Equal(t, tt.wantAllow, allowedMethods)
+			assert.Equal(t, tt.wantStatus, recorder.Code)
+			assert.Equal(t, tt.wantBody, recorder.Body.String())
+			assert.Equal(t, tt.wantAllow, recorder.Header().Get("Allow"))
 		})
 	}
 }

--- a/internal/protocols/strategies/HTTP/http_test.go
+++ b/internal/protocols/strategies/HTTP/http_test.go
@@ -524,80 +524,56 @@ func TestTraceRequest_RemoteAddr_IPv6WithoutPort(t *testing.T) {
 	assert.Equal(t, "2001:db8::42", ev.RemoteAddr)
 }
 
-func TestHTTPHandler_MethodRouting(t *testing.T) {
+func TestMatchHTTPCommand(t *testing.T) {
+	commands := []parser.Command{
+		{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodGet}, Handler: "get"},
+		{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodPost}, Handler: "post"},
+		{Regex: regexp.MustCompile(`^/open$`), Handler: "open"},
+	}
 	tests := []struct {
-		name       string
-		method     string
-		path       string
-		commands   []parser.Command
-		fallback   parser.Command
-		wantStatus int
-		wantBody   string
-		wantAllow  string
+		name        string
+		method      string
+		path        string
+		wantHandler string
+		wantAllow   []string
 	}{
 		{
-			name:       "allowed method",
-			method:     http.MethodPost,
-			path:       "/api/generate",
-			commands:   []parser.Command{{Regex: regexp.MustCompile(`^/api/generate$`), Methods: []string{http.MethodPost}, Handler: "generated", StatusCode: http.StatusOK}},
-			wantStatus: http.StatusOK,
-			wantBody:   "generated",
+			name:        "later command accepts method",
+			method:      http.MethodPost,
+			path:        "/same",
+			wantHandler: "post",
 		},
 		{
-			name:       "missing list accepts every method",
-			method:     http.MethodPatch,
-			path:       "/open",
-			commands:   []parser.Command{{Regex: regexp.MustCompile(`^/open$`), Handler: "open", StatusCode: http.StatusOK}},
-			wantStatus: http.StatusOK,
-			wantBody:   "open",
+			name:        "missing methods accepts every method",
+			method:      http.MethodPatch,
+			path:        "/open",
+			wantHandler: "open",
 		},
 		{
-			name:   "later command accepts method",
-			method: http.MethodPost,
-			path:   "/same",
-			commands: []parser.Command{
-				{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodGet}, Handler: "get", StatusCode: http.StatusOK},
-				{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodPost}, Handler: "post", StatusCode: http.StatusCreated},
-			},
-			wantStatus: http.StatusCreated,
-			wantBody:   "post",
+			name:      "known path rejects method",
+			method:    http.MethodDelete,
+			path:      "/same",
+			wantAllow: []string{http.MethodGet, http.MethodPost},
 		},
 		{
-			name:   "known URL rejects method",
-			method: http.MethodDelete,
-			path:   "/same",
-			commands: []parser.Command{
-				{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodGet, http.MethodPost}, Handler: "wrong", StatusCode: http.StatusOK},
-				{Regex: regexp.MustCompile(`^/same$`), Methods: []string{http.MethodPost}, Handler: "wrong", StatusCode: http.StatusOK},
-			},
-			fallback:   parser.Command{Handler: "fallback", StatusCode: http.StatusNotFound},
-			wantStatus: http.StatusMethodNotAllowed,
-			wantBody:   http.StatusText(http.StatusMethodNotAllowed),
-			wantAllow:  "GET, POST",
-		},
-		{
-			name:       "unknown URL uses fallback",
-			method:     http.MethodGet,
-			path:       "/missing",
-			commands:   []parser.Command{{Regex: regexp.MustCompile(`^/known$`), Methods: []string{http.MethodGet}, Handler: "known", StatusCode: http.StatusOK}},
-			fallback:   parser.Command{Handler: "fallback", StatusCode: http.StatusNotFound},
-			wantStatus: http.StatusNotFound,
-			wantBody:   "fallback",
+			name:   "unknown path has no allowed methods",
+			method: http.MethodGet,
+			path:   "/missing",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			recorder := httptest.NewRecorder()
 			request := httptest.NewRequest(tt.method, tt.path, nil)
-			newHTTPHandler(parser.BeelzebubServiceConfiguration{
-				Commands:        tt.commands,
-				FallbackCommand: tt.fallback,
-			}, &mockTracer{}).ServeHTTP(recorder, request)
+			command, allowedMethods := matchHTTPCommand(commands, request)
 
-			assert.Equal(t, tt.wantStatus, recorder.Code)
-			assert.Equal(t, tt.wantBody, recorder.Body.String())
-			assert.Equal(t, tt.wantAllow, recorder.Header().Get("Allow"))
+			if tt.wantHandler == "" {
+				assert.Nil(t, command)
+			} else {
+				require.NotNil(t, command)
+				assert.Equal(t, tt.wantHandler, command.Handler)
+			}
+			assert.Equal(t, tt.wantAllow, allowedMethods)
 		})
 	}
 }

--- a/specs/runtime-config.schema.json
+++ b/specs/runtime-config.schema.json
@@ -161,6 +161,11 @@
       "type": "object",
       "properties": {
         "regex": { "type": "string" },
+        "methods": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
         "handler": { "type": "string" },
         "headers": {
           "type": "array",

--- a/specs/runtime-http.schema.json
+++ b/specs/runtime-http.schema.json
@@ -7,7 +7,18 @@
     {
       "required": ["commands"],
       "properties": {
-        "commands": { "minItems": 1 },
+        "commands": {
+          "minItems": 1,
+          "items": {
+            "properties": {
+              "methods": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 1 },
+                "uniqueItems": true
+              }
+            }
+          }
+        },
         "tools": false
       }
     }

--- a/specs/runtime-http.schema.json
+++ b/specs/runtime-http.schema.json
@@ -13,7 +13,7 @@
             "properties": {
               "methods": {
                 "type": "array",
-                "items": { "type": "string", "minLength": 1 },
+                "items": { "type": "string", "pattern": "^[!#$%&'*+.^_`|~0-9A-Za-z-]+$" },
                 "uniqueItems": true
               }
             }


### PR DESCRIPTION
## All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally before submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

## Summary

Adds method-aware routing to HTTP honeypot commands.

Each HTTP command can declare an optional list of accepted methods. When a URL matches but none of its commands accepts the request
method, Beelzebub returns `405 Method Not Allowed` with an `Allow` header listing the accepted methods.

Existing configurations remain backward compatible: omitting `methods`, or configuring an empty list, accepts every method.

## Why

This improves resistance to honeypot fingerprinting.

Real HTTP services expose specific methods for each endpoint. For example, an API may accept `GET` for discovery endpoints and
`POST` for generation or mutation endpoints. Returning the same configured response regardless of the request method creates
behavior that differs from the service being emulated and can help scanners identify the honeypot.

Method-aware routing allows Beelzebub decoys to reproduce the expected HTTP behavior of real services, including method rejection and the standard `Allow` response header.

## What changed

### HTTP routing

- Added exact, case-sensitive method matching alongside URL regex matching.
- Continued searching after a URL match with an unsupported method, allowing different handlers for the same URL and different
  methods.
- Added `405 Method Not Allowed` responses.
- Added an ordered, deduplicated `Allow` header.
- Prevented `fallbackCommand` from handling a known URL when no matching command accepts the method.
- Preserved fallback behavior when no command regex matches.
- Preserved unrestricted behavior when `methods` is omitted or empty.
- Extracted the HTTP handler so routing behavior can be tested without opening a network port.

### Configuration and schema validation

Commands can now declare an optional `methods` list:

```yaml
commands:
  - regex: "^/hello$"
    methods: [GET]
    handler: "Hello!"
    statusCode: 200
```

The JSON Schema requires method lists to contain unique, non-empty strings.

The configuration validation rule matrix was updated with the new `commands[].methods` rule.

### Example service

Added `configurations/services/http-methods-8081.yaml`:

```yaml
apiVersion: "v1"
protocol: "http"
address: ":8081"
description: "HTTP method example"
commands:
  - regex: "^/hello$"
    methods: [GET]
    handler: "Hello!"
    statusCode: 200
  - regex: "^/submit$"
    methods: [POST]
    handler: "Submitted!"
    statusCode: 200
fallbackCommand:
  handler: "404 Not Found!"
  statusCode: 404
```

Behavior:

- `GET /hello` returns `200`.
- `POST /submit` returns `200`.
- `POST /hello` returns `405` with `Allow: GET`.
- An unknown URL returns the configured `404` fallback.

### Documentation

- Updated the README HTTP examples with method lists.
- Documented unrestricted commands, 405 responses, `Allow`, and catch-all behavior.
- Updated the configuration-validation rule matrix.

## Testing

Added parser and schema tests for:

- Parsing method lists from YAML.
- Accepting valid method lists.
- Rejecting duplicate methods.

Added table-driven HTTP routing tests for:

- An accepted request method.
- An omitted method list accepting every method.
- Selecting a later command that accepts the method.
- Returning 405 for a known URL with an unsupported method.
- Producing an ordered, deduplicated `Allow` header.
- Invoking the fallback for an unmatched URL.

Validation performed locally:

```text
go test ./... -count=1
go vet ./...
make validate-all
```

Results:

```text
All Go packages passed.
18/18 service schemas passed.
Configuration validation completed with 0 errors.
```

Manual verification:

```bash
curl -i http://localhost:8081/hello
curl -i -X POST http://localhost:8081/submit
curl -i -X POST http://localhost:8081/hello
```

The last command gives:
```
curl -i -X POST http://localhost:8081/hello
HTTP/1.1 405 Method Not Allowed
Allow: GET
Date: Fri, 07 Aug 2026 06:27:59 GMT
Content-Length: 18
Content-Type: text/plain; charset=utf-8

Method Not Allowed
```