### PR TITLE
fix(parser): redact secrets when configurations are logged

### DIFF
--- a/internal/parser/redact.go
+++ b/internal/parser/redact.go
@@ -1,0 +1,102 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+)
+
+// redactedPlaceholder replaces secret values when a configuration struct is
+// formatted for logging.
+const redactedPlaceholder = "[REDACTED]"
+
+// redactSecret hides a secret value while preserving the distinction between
+// "configured" and "not configured", which debug logs still need to be useful.
+func redactSecret(value string) string {
+	if value == "" {
+		return ""
+	}
+	return redactedPlaceholder
+}
+
+// Format redacts the OpenAI secret key whenever a Plugin is printed.
+//
+// Debug logging dumps the whole service configuration (see readConfigurationsServices),
+// so redaction belongs on the struct rather than at each call site: any future
+// log line that formats a configuration is then safe by construction.
+//
+// Implementing fmt.Formatter rather than fmt.Stringer preserves the caller's
+// verb and flags, so "%+v" keeps printing field names.
+//
+// This deliberately does not touch MarshalJSON: HashCode marshals the
+// configuration to detect drift, and redacting there would make the hash of
+// every secret-bearing configuration identical.
+func (plugin Plugin) Format(state fmt.State, verb rune) {
+	type plain Plugin
+
+	redacted := plain(plugin)
+	redacted.OpenAISecretKey = redactSecret(redacted.OpenAISecretKey)
+
+	fmt.Fprintf(state, fmt.FormatString(state, verb), redacted)
+}
+
+// sensitiveConfigKeys are the configuration keys whose values are secrets.
+//
+// Matching is exact rather than by substring on purpose: "passwordRegex" is not
+// a secret, and redacting it would make debug logs useless for the SSH
+// honeypot. A new secret-bearing configuration field must be added here.
+var sensitiveConfigKeys = map[string]struct{}{
+	"openaisecretkey": {},
+	"auth-token":      {},
+	"authtoken":       {},
+}
+
+// Format redacts secrets whenever a service configuration is printed.
+//
+// The typed Plugin field is handled by Plugin.Format, but RawConfig holds the
+// original parsed document and would otherwise reprint every secret verbatim.
+func (config BeelzebubServiceConfiguration) Format(state fmt.State, verb rune) {
+	type plain BeelzebubServiceConfiguration
+
+	redacted := plain(config)
+	redacted.RawConfig = redactRawConfig(config.RawConfig)
+
+	fmt.Fprintf(state, fmt.FormatString(state, verb), redacted)
+}
+
+// redactRawConfig returns a copy of a parsed configuration document with secret
+// values replaced. It copies rather than edits in place: the caller is only
+// formatting the configuration, and must not damage the one being served.
+func redactRawConfig(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(typed))
+		for key, nested := range typed {
+			if _, sensitive := sensitiveConfigKeys[strings.ToLower(key)]; sensitive {
+				if text, ok := nested.(string); ok {
+					result[key] = redactSecret(text)
+					continue
+				}
+			}
+			result[key] = redactRawConfig(nested)
+		}
+		return result
+	case []any:
+		result := make([]any, len(typed))
+		for i, nested := range typed {
+			result[i] = redactRawConfig(nested)
+		}
+		return result
+	default:
+		return value
+	}
+}
+
+// Format redacts the cloud auth token whenever a BeelzebubCloud is printed.
+func (cloud BeelzebubCloud) Format(state fmt.State, verb rune) {
+	type plain BeelzebubCloud
+
+	redacted := plain(cloud)
+	redacted.AuthToken = redactSecret(redacted.AuthToken)
+
+	fmt.Fprintf(state, fmt.FormatString(state, verb), redacted)
+}

--- a/internal/parser/redact.go
+++ b/internal/parser/redact.go
@@ -5,12 +5,9 @@ import (
 	"strings"
 )
 
-// redactedPlaceholder replaces secret values when a configuration struct is
-// formatted for logging.
 const redactedPlaceholder = "[REDACTED]"
 
-// redactSecret hides a secret value while preserving the distinction between
-// "configured" and "not configured", which debug logs still need to be useful.
+// redactSecret keeps the distinction between "configured" and "not configured".
 func redactSecret(value string) string {
 	if value == "" {
 		return ""
@@ -20,16 +17,10 @@ func redactSecret(value string) string {
 
 // Format redacts the OpenAI secret key whenever a Plugin is printed.
 //
-// Debug logging dumps the whole service configuration (see readConfigurationsServices),
-// so redaction belongs on the struct rather than at each call site: any future
-// log line that formats a configuration is then safe by construction.
-//
-// Implementing fmt.Formatter rather than fmt.Stringer preserves the caller's
-// verb and flags, so "%+v" keeps printing field names.
-//
-// This deliberately does not touch MarshalJSON: HashCode marshals the
-// configuration to detect drift, and redacting there would make the hash of
-// every secret-bearing configuration identical.
+// fmt.Formatter rather than fmt.Stringer so "%+v" keeps printing field names.
+// MarshalJSON is deliberately left alone: HashCode marshals the configuration
+// to detect drift, and redacting there would make every secret-bearing config
+// hash alike.
 func (plugin Plugin) Format(state fmt.State, verb rune) {
 	type plain Plugin
 
@@ -39,21 +30,17 @@ func (plugin Plugin) Format(state fmt.State, verb rune) {
 	fmt.Fprintf(state, fmt.FormatString(state, verb), redacted)
 }
 
-// sensitiveConfigKeys are the configuration keys whose values are secrets.
-//
-// Matching is exact rather than by substring on purpose: "passwordRegex" is not
-// a secret, and redacting it would make debug logs useless for the SSH
-// honeypot. A new secret-bearing configuration field must be added here.
+// sensitiveConfigKeys is matched exactly, not by substring: "passwordRegex" is
+// not a secret. New secret-bearing fields must be added here.
 var sensitiveConfigKeys = map[string]struct{}{
 	"openaisecretkey": {},
 	"auth-token":      {},
 	"authtoken":       {},
 }
 
-// Format redacts secrets whenever a service configuration is printed.
-//
-// The typed Plugin field is handled by Plugin.Format, but RawConfig holds the
-// original parsed document and would otherwise reprint every secret verbatim.
+// Format redacts secrets whenever a service configuration is printed. The typed
+// Plugin field is handled by Plugin.Format; RawConfig holds the original parsed
+// document and would otherwise reprint every secret verbatim.
 func (config BeelzebubServiceConfiguration) Format(state fmt.State, verb rune) {
 	type plain BeelzebubServiceConfiguration
 
@@ -63,8 +50,19 @@ func (config BeelzebubServiceConfiguration) Format(state fmt.State, verb rune) {
 	fmt.Fprintf(state, fmt.FormatString(state, verb), redacted)
 }
 
-// redactRawConfig returns a copy of a parsed configuration document with secret
-// values replaced. It copies rather than edits in place: the caller is only
+// redactSensitiveValue hides a secret whatever its type: configuration supplied
+// as JSON can hold a non-string scalar. Null means "not configured".
+func redactSensitiveValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	if text, ok := value.(string); ok {
+		return redactSecret(text)
+	}
+	return redactedPlaceholder
+}
+
+// redactRawConfig copies rather than edits in place: the caller is only
 // formatting the configuration, and must not damage the one being served.
 func redactRawConfig(value any) any {
 	switch typed := value.(type) {
@@ -72,10 +70,8 @@ func redactRawConfig(value any) any {
 		result := make(map[string]any, len(typed))
 		for key, nested := range typed {
 			if _, sensitive := sensitiveConfigKeys[strings.ToLower(key)]; sensitive {
-				if text, ok := nested.(string); ok {
-					result[key] = redactSecret(text)
-					continue
-				}
+				result[key] = redactSensitiveValue(nested)
+				continue
 			}
 			result[key] = redactRawConfig(nested)
 		}

--- a/internal/parser/redact_test.go
+++ b/internal/parser/redact_test.go
@@ -9,8 +9,7 @@ import (
 
 const fakeSecret = "sk-proj-000NOTAREALKEY111DEADBEEF222"
 
-// Debug logging formats the whole service configuration with the fmt verbs, so
-// every secret-bearing struct must redact itself when printed. See issue #349.
+// See issue #349: debug logging formats the whole service configuration.
 func TestPluginStringRedactsOpenAISecretKey(t *testing.T) {
 	plugin := Plugin{
 		OpenAISecretKey: fakeSecret,
@@ -22,7 +21,6 @@ func TestPluginStringRedactsOpenAISecretKey(t *testing.T) {
 
 	assert.NotContains(t, printed, fakeSecret)
 	assert.Contains(t, printed, redactedPlaceholder)
-	// Non-sensitive fields must survive, or debug logging loses its purpose.
 	assert.Contains(t, printed, "gpt-4o")
 	assert.Contains(t, printed, "openai")
 }
@@ -30,13 +28,12 @@ func TestPluginStringRedactsOpenAISecretKey(t *testing.T) {
 func TestPluginStringKeepsEmptySecretEmpty(t *testing.T) {
 	printed := fmt.Sprintf("%v", Plugin{LLMModel: "gpt-4o"})
 
-	// An unset key is not a secret; printing [REDACTED] would be misleading.
+	// An unset key is not a secret.
 	assert.NotContains(t, printed, redactedPlaceholder)
 	assert.Contains(t, printed, "gpt-4o")
 }
 
-// The leak in #349 is a whole-config dump, so redaction has to survive being
-// reached through the parent struct and through a pointer to it.
+// Redaction must survive the parent struct and a pointer to it.
 func TestServiceConfigurationStringRedactsNestedSecret(t *testing.T) {
 	config := &BeelzebubServiceConfiguration{
 		Protocol:    "http",
@@ -52,8 +49,7 @@ func TestServiceConfigurationStringRedactsNestedSecret(t *testing.T) {
 	}
 }
 
-// RawConfig keeps the original parsed document, so the secret survives there
-// even after the typed field is redacted. This is the path that actually leaked.
+// RawConfig keeps the original parsed document. This is the path that leaked.
 func TestServiceConfigurationStringRedactsRawConfig(t *testing.T) {
 	config := &BeelzebubServiceConfiguration{
 		Protocol: "http",
@@ -72,8 +68,7 @@ func TestServiceConfigurationStringRedactsRawConfig(t *testing.T) {
 	assert.Contains(t, printed, "gpt-4o")
 }
 
-// Redacting the printed copy must not mutate the configuration itself, or the
-// second log line would print a configuration whose key has been destroyed.
+// Formatting must not mutate the configuration being served.
 func TestRawConfigRedactionDoesNotMutateOriginal(t *testing.T) {
 	plugin := map[string]any{"openAISecretKey": fakeSecret}
 	config := &BeelzebubServiceConfiguration{
@@ -85,14 +80,55 @@ func TestRawConfigRedactionDoesNotMutateOriginal(t *testing.T) {
 	assert.Equal(t, fakeSecret, plugin["openAISecretKey"])
 }
 
-// passwordRegex is not a secret. Over-redaction would make debug logs useless
-// for the SSH honeypot, so key matching must be exact rather than substring.
+// passwordRegex is not a secret; key matching must be exact, not substring.
 func TestRawConfigKeepsNonSecretLookalikeKeys(t *testing.T) {
 	config := &BeelzebubServiceConfiguration{
 		RawConfig: map[string]any{"passwordRegex": "^(root|admin)$"},
 	}
 
 	assert.Contains(t, fmt.Sprintf("%v", config), "^(root|admin)$")
+}
+
+// Real documents nest secrets under lists, so the walk must descend slices.
+func TestRawConfigRedactsSecretNestedInList(t *testing.T) {
+	config := &BeelzebubServiceConfiguration{
+		RawConfig: map[string]any{
+			"services": []any{
+				map[string]any{"plugin": map[string]any{"openAISecretKey": fakeSecret}},
+				map[string]any{"description": "second service"},
+			},
+		},
+	}
+
+	printed := fmt.Sprintf("%v", config)
+
+	assert.NotContains(t, printed, fakeSecret)
+	assert.Contains(t, printed, "second service")
+}
+
+// Configuration supplied as JSON can hold a non-string scalar.
+func TestRawConfigRedactsNonStringSecret(t *testing.T) {
+	config := &BeelzebubServiceConfiguration{
+		RawConfig: map[string]any{
+			"plugin": map[string]any{"openAISecretKey": 1234567890},
+		},
+	}
+
+	printed := fmt.Sprintf("%v", config)
+
+	assert.NotContains(t, printed, "1234567890")
+	assert.Contains(t, printed, redactedPlaceholder)
+}
+
+// A null key is not configured, so it must not read as a secret.
+func TestRawConfigLeavesNullSecretAlone(t *testing.T) {
+	config := &BeelzebubServiceConfiguration{
+		RawConfig: map[string]any{
+			"plugin": map[string]any{"openAISecretKey": nil},
+		},
+	}
+
+	assert.NotContains(t, fmt.Sprintf("%v", config), redactedPlaceholder)
 }
 
 func TestBeelzebubCloudStringRedactsAuthToken(t *testing.T) {
@@ -109,8 +145,7 @@ func TestBeelzebubCloudStringRedactsAuthToken(t *testing.T) {
 	assert.Contains(t, printed, "https://cloud.example/events")
 }
 
-// HashCode feeds config-drift detection, so redaction must not reach the JSON
-// encoder: a redacted hash would change on every deployment that sets a key.
+// Redaction must not reach the JSON encoder that HashCode uses.
 func TestHashCodeIsUnaffectedByRedaction(t *testing.T) {
 	withSecret := BeelzebubServiceConfiguration{
 		Protocol: "http", Address: ":8080",

--- a/internal/parser/redact_test.go
+++ b/internal/parser/redact_test.go
@@ -1,0 +1,130 @@
+package parser
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const fakeSecret = "sk-proj-000NOTAREALKEY111DEADBEEF222"
+
+// Debug logging formats the whole service configuration with the fmt verbs, so
+// every secret-bearing struct must redact itself when printed. See issue #349.
+func TestPluginStringRedactsOpenAISecretKey(t *testing.T) {
+	plugin := Plugin{
+		OpenAISecretKey: fakeSecret,
+		LLMModel:        "gpt-4o",
+		LLMProvider:     "openai",
+	}
+
+	printed := fmt.Sprintf("%v", plugin)
+
+	assert.NotContains(t, printed, fakeSecret)
+	assert.Contains(t, printed, redactedPlaceholder)
+	// Non-sensitive fields must survive, or debug logging loses its purpose.
+	assert.Contains(t, printed, "gpt-4o")
+	assert.Contains(t, printed, "openai")
+}
+
+func TestPluginStringKeepsEmptySecretEmpty(t *testing.T) {
+	printed := fmt.Sprintf("%v", Plugin{LLMModel: "gpt-4o"})
+
+	// An unset key is not a secret; printing [REDACTED] would be misleading.
+	assert.NotContains(t, printed, redactedPlaceholder)
+	assert.Contains(t, printed, "gpt-4o")
+}
+
+// The leak in #349 is a whole-config dump, so redaction has to survive being
+// reached through the parent struct and through a pointer to it.
+func TestServiceConfigurationStringRedactsNestedSecret(t *testing.T) {
+	config := &BeelzebubServiceConfiguration{
+		Protocol:    "http",
+		Address:     ":8080",
+		Description: "LLM lure",
+		Plugin:      Plugin{OpenAISecretKey: fakeSecret},
+	}
+
+	for _, format := range []string{"%v", "%+v", "%s"} {
+		printed := fmt.Sprintf(format, config)
+		assert.NotContains(t, printed, fakeSecret, "leaked with %s", format)
+		assert.Contains(t, printed, "LLM lure", "dropped context with %s", format)
+	}
+}
+
+// RawConfig keeps the original parsed document, so the secret survives there
+// even after the typed field is redacted. This is the path that actually leaked.
+func TestServiceConfigurationStringRedactsRawConfig(t *testing.T) {
+	config := &BeelzebubServiceConfiguration{
+		Protocol: "http",
+		RawConfig: map[string]any{
+			"protocol": "http",
+			"plugin": map[string]any{
+				"openAISecretKey": fakeSecret,
+				"llmModel":        "gpt-4o",
+			},
+		},
+	}
+
+	printed := fmt.Sprintf("%v", config)
+
+	assert.NotContains(t, printed, fakeSecret)
+	assert.Contains(t, printed, "gpt-4o")
+}
+
+// Redacting the printed copy must not mutate the configuration itself, or the
+// second log line would print a configuration whose key has been destroyed.
+func TestRawConfigRedactionDoesNotMutateOriginal(t *testing.T) {
+	plugin := map[string]any{"openAISecretKey": fakeSecret}
+	config := &BeelzebubServiceConfiguration{
+		RawConfig: map[string]any{"plugin": plugin},
+	}
+
+	_ = fmt.Sprintf("%v", config)
+
+	assert.Equal(t, fakeSecret, plugin["openAISecretKey"])
+}
+
+// passwordRegex is not a secret. Over-redaction would make debug logs useless
+// for the SSH honeypot, so key matching must be exact rather than substring.
+func TestRawConfigKeepsNonSecretLookalikeKeys(t *testing.T) {
+	config := &BeelzebubServiceConfiguration{
+		RawConfig: map[string]any{"passwordRegex": "^(root|admin)$"},
+	}
+
+	assert.Contains(t, fmt.Sprintf("%v", config), "^(root|admin)$")
+}
+
+func TestBeelzebubCloudStringRedactsAuthToken(t *testing.T) {
+	const token = "bzb-cloud-000NOTAREALTOKEN111"
+
+	printed := fmt.Sprintf("%v", BeelzebubCloud{
+		Enabled:   true,
+		URI:       "https://cloud.example/events",
+		AuthToken: token,
+	})
+
+	assert.NotContains(t, printed, token)
+	assert.Contains(t, printed, redactedPlaceholder)
+	assert.Contains(t, printed, "https://cloud.example/events")
+}
+
+// HashCode feeds config-drift detection, so redaction must not reach the JSON
+// encoder: a redacted hash would change on every deployment that sets a key.
+func TestHashCodeIsUnaffectedByRedaction(t *testing.T) {
+	withSecret := BeelzebubServiceConfiguration{
+		Protocol: "http", Address: ":8080",
+		Plugin: Plugin{OpenAISecretKey: fakeSecret},
+	}
+	withoutSecret := BeelzebubServiceConfiguration{
+		Protocol: "http", Address: ":8080",
+		Plugin: Plugin{OpenAISecretKey: "a-different-key"},
+	}
+
+	first, err := withSecret.HashCode()
+	assert.Nil(t, err)
+	second, err := withoutSecret.HashCode()
+	assert.Nil(t, err)
+
+	assert.NotEqual(t, first, second, "HashCode must still see the real key")
+}


### PR DESCRIPTION
Fixes #349. @mariocandela you said feel free to open one, so here it is 🙂

## All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

## What was happening

`readConfigurationsServices` logs each parsed service configuration, and the struct contains the key:

```go
log.Debug(beelzebubServiceConfiguration)
```

```
level=debug msg="&{llm.yaml v1 http :18096 ... {sk-proj-EXAMPLEKEYNOTREAL  gpt-4o openai ...
```

Two things I found while reproducing it that aren't in the issue:

**It also leaks from `validate`, not just `run`.** That one is arguably worse, because `validate` output is exactly what someone pastes into a bug report.

**`RawConfig` leaks it a second time.** Redacting the typed `Plugin` field isn't enough — `RawConfig` keeps the original parsed document, so the key gets reprinted verbatim in the same log line. I only caught this because I checked the real log output instead of trusting my unit tests, which were happily passing at the time.

On the Authorization header you mentioned: I looked and I think that path is already fine. resty's `Response.String()` returns only the response body, and there's no `SetDebug` anywhere, so `log.Debug(response)` never prints request headers. Happy to be wrong if you had a different spot in mind.

## The fix

Redaction goes on the config structs as `fmt.Formatter`, not at the call site, so any future log line that formats a configuration is safe by construction. `fmt.Formatter` rather than `fmt.Stringer` so the caller's verb and flags survive and `%+v` still prints field names.

```
plugin:map[llmModel:gpt-4o llmProvider:openai openAISecretKey:[REDACTED]]
```

An unset key stays empty rather than printing `[REDACTED]`, so debug logs still tell you whether a key is configured.

`RawConfig` is redacted on a **copy** — the served configuration is never modified. Key matching is exact, not substring, because `passwordRegex` is not a secret and redacting it would make debug logs useless for the secure-shell honeypot. `BeelzebubCloud.AuthToken` gets the same treatment since it's the same class of value.

`MarshalJSON` is deliberately untouched: `HashCode` marshals the configuration to detect drift, and redacting there would make every secret-bearing config hash alike. There's a test pinning that.

## Testing

Two new files, nothing existing modified. 8 new tests covering the typed field, the nested/pointer path, `RawConfig`, non-mutation, the `passwordRegex` lookalike, and hash stability.

```
go test ./... -count=1     # all 17 packages pass
go test ./internal/parser/ -race
go vet ./...
gofmt -l .                 # clean
```

End to end, with a fake key in `plugin.openAISecretKey`:

| | `validate` | `run` |
|---|---|---|
| before | leaked | leaked |
| after | clean | clean |
